### PR TITLE
[Feature #4] 장바구니 상품 목록 주문 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.flab'
-version = '0.0.1-SNAPSHOT'
+version = '1.0.0-SNAPSHOT'
 
 java {
 	sourceCompatibility = '17'

--- a/src/main/java/com/flab/order/controller/OrderController.java
+++ b/src/main/java/com/flab/order/controller/OrderController.java
@@ -1,7 +1,10 @@
 package com.flab.order.controller;
 
 import com.flab.order.domain.dto.OrderResponse;
+import com.flab.order.global.resolver.LoginMember;
 import com.flab.order.global.response.ApiResponse;
+import com.flab.order.global.session.SessionMember;
+import com.flab.order.service.OrderService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -14,10 +17,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/orders")
 public class OrderController {
+    private final OrderService orderService;
 
     @Operation(summary = "장바구니 상품 주문 API")
     @PostMapping()
-    public ApiResponse<OrderResponse.Success> orderCartItems(){
-        return null;
+    public ApiResponse<OrderResponse.Success> orderCartItems(@LoginMember SessionMember member){
+        return ApiResponse.onSuccess(orderService.orderCartItems(member.getMemberId()));
     }
 }

--- a/src/main/java/com/flab/order/controller/OrderController.java
+++ b/src/main/java/com/flab/order/controller/OrderController.java
@@ -1,0 +1,23 @@
+package com.flab.order.controller;
+
+import com.flab.order.domain.dto.OrderResponse;
+import com.flab.order.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "주문 API", description = "주문 관련 API 입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/orders")
+public class OrderController {
+
+    @Operation(summary = "장바구니 상품 주문 API")
+    @PostMapping()
+    public ApiResponse<OrderResponse.Success> orderCartItems(){
+        return null;
+    }
+}

--- a/src/main/java/com/flab/order/converter/OrderConverter.java
+++ b/src/main/java/com/flab/order/converter/OrderConverter.java
@@ -1,0 +1,39 @@
+package com.flab.order.converter;
+
+import com.flab.order.domain.dto.OrderResponse;
+import com.flab.order.domain.entity.Product;
+import com.flab.order.domain.entity.Status;
+import com.flab.order.domain.vo.CartValidationResult;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OrderConverter {
+    public static OrderResponse.ProductInfo toProductInfo(Product product) {
+        return OrderResponse.ProductInfo.builder()
+                .name(product.getName())
+                .price(product.getPrice())
+                .stock(product.getStock())
+                .build();
+    }
+
+    public static OrderResponse.Details toDetails(CartValidationResult validationResult) {
+        List<OrderResponse.ProductInfo> productInfos = validationResult.getCartItemList().stream()
+                .map(cartItem -> toProductInfo(cartItem.getProduct()))
+                .collect(Collectors.toList());
+
+        return OrderResponse.Details.builder()
+                .productInfoList(productInfos)
+                .totalPrice(validationResult.getTotalPrice())
+                .build();
+    }
+
+    public static OrderResponse.Success toSuccess(CartValidationResult validationResult) {
+        OrderResponse.Details details = toDetails(validationResult);
+
+        return OrderResponse.Success.builder()
+                .orderStatus(Status.COMPLETE)
+                .productDetails(details)
+                .build();
+    }
+}

--- a/src/main/java/com/flab/order/domain/dto/OrderResponse.java
+++ b/src/main/java/com/flab/order/domain/dto/OrderResponse.java
@@ -1,21 +1,37 @@
 package com.flab.order.domain.dto;
 
 import com.flab.order.domain.entity.Status;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.Instant;
 import java.util.List;
 
 public class OrderResponse {
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Builder
     public static class Success{
         private Status orderStatus;
         private Details productDetails;
     }
 
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Builder
     public static class Details{
         private List<ProductInfo> productInfoList;
         private Integer totalPrice;
     }
 
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Builder
     public static class ProductInfo{
         private String name;
         private Integer price;

--- a/src/main/java/com/flab/order/domain/dto/OrderResponse.java
+++ b/src/main/java/com/flab/order/domain/dto/OrderResponse.java
@@ -1,0 +1,24 @@
+package com.flab.order.domain.dto;
+
+import com.flab.order.domain.entity.Status;
+
+import java.time.Instant;
+import java.util.List;
+
+public class OrderResponse {
+    public static class Success{
+        private Status orderStatus;
+        private Details productDetails;
+    }
+
+    public static class Details{
+        private List<ProductInfo> productInfoList;
+        private Integer totalPrice;
+    }
+
+    public static class ProductInfo{
+        private String name;
+        private Integer price;
+        private Integer stock;
+    }
+}

--- a/src/main/java/com/flab/order/domain/entity/Cart.java
+++ b/src/main/java/com/flab/order/domain/entity/Cart.java
@@ -3,12 +3,16 @@ package com.flab.order.domain.entity;
 import com.flab.order.global.exception.GeneralHandler;
 import com.flab.order.global.response.statusEnums.ErrorStatus;
 import lombok.Getter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.List;
 
 @Getter
 public class Cart {
+    Logger logger = LoggerFactory.getLogger(Cart.class);
+
     private Long memberId;
     private Long productId;
     private Integer quantity;
@@ -19,6 +23,7 @@ public class Cart {
 
     public void validateStock() {
         if (this.product.getStock() < this.quantity) {
+            logger.error("상품 재고 부족: 회원 ID = {}, 제품 ID = {}", memberId, productId);
             throw new GeneralHandler(ErrorStatus.INVALID_QUANTITY);
         }
     }

--- a/src/main/java/com/flab/order/domain/entity/Cart.java
+++ b/src/main/java/com/flab/order/domain/entity/Cart.java
@@ -1,8 +1,11 @@
 package com.flab.order.domain.entity;
 
+import com.flab.order.global.exception.GeneralHandler;
+import com.flab.order.global.response.statusEnums.ErrorStatus;
 import lombok.Getter;
 
 import java.time.Instant;
+import java.util.List;
 
 @Getter
 public class Cart {
@@ -13,4 +16,14 @@ public class Cart {
 
     // 연관된 상품 객체
     private Product product;
+
+    public void validateStock() {
+        if (this.product.getStock() < this.quantity) {
+            throw new GeneralHandler(ErrorStatus.INVALID_QUANTITY);
+        }
+    }
+
+    public int calculatePrice() {
+        return this.product.getPrice() * this.quantity;
+    }
 }

--- a/src/main/java/com/flab/order/domain/entity/Cart.java
+++ b/src/main/java/com/flab/order/domain/entity/Cart.java
@@ -10,4 +10,7 @@ public class Cart {
     private Long productId;
     private Integer quantity;
     private Instant createdAt;
+
+    // 연관된 상품 객체
+    private Product product;
 }

--- a/src/main/java/com/flab/order/domain/entity/OrderDetail.java
+++ b/src/main/java/com/flab/order/domain/entity/OrderDetail.java
@@ -8,4 +8,13 @@ public class OrderDetail {
     private Long productId;
     private Integer price;
     private Integer quantity;
+
+    public static OrderDetail createOrderDetail(Long orderId, Cart cart) {
+        OrderDetail orderDetail = new OrderDetail();
+        orderDetail.orderId = orderId;
+        orderDetail.productId = cart.getProduct().getId();
+        orderDetail.price = cart.getProduct().getPrice();
+        orderDetail.quantity = cart.getQuantity();
+        return orderDetail;
+    }
 }

--- a/src/main/java/com/flab/order/domain/entity/Orders.java
+++ b/src/main/java/com/flab/order/domain/entity/Orders.java
@@ -3,6 +3,7 @@ package com.flab.order.domain.entity;
 import lombok.Getter;
 
 import java.time.Instant;
+import java.util.List;
 
 @Getter
 public class Orders {
@@ -12,4 +13,14 @@ public class Orders {
     private Integer totalPrice;
     private Instant createdAt;
     private Instant updatedAt;
+
+    public static Orders createOrder(Long memberId, Integer totalPrice) {
+        Orders order = new Orders();
+        order.memberId = memberId;
+        order.status = Status.PENDING;
+        order.totalPrice = totalPrice;
+        order.createdAt = Instant.now();
+        order.updatedAt = Instant.now();
+        return order;
+    }
 }

--- a/src/main/java/com/flab/order/domain/entity/Payment.java
+++ b/src/main/java/com/flab/order/domain/entity/Payment.java
@@ -12,4 +12,14 @@ public class Payment {
     private Status status;
     private Instant createdAt;
     private Instant updatedAt;
+
+    public static Payment createPayment(Long orderId, int totalPrice) {
+        Payment payment = new Payment();
+        payment.orderId = orderId;
+        payment.amount = totalPrice;
+        payment.status = Status.COMPLETE;
+        payment.createdAt = Instant.now();
+        payment.updatedAt = Instant.now();
+        return payment;
+    }
 }

--- a/src/main/java/com/flab/order/domain/vo/CartValidationResult.java
+++ b/src/main/java/com/flab/order/domain/vo/CartValidationResult.java
@@ -1,0 +1,12 @@
+package com.flab.order.domain.vo;
+
+import com.flab.order.domain.entity.Cart;
+import lombok.Value;
+
+import java.util.List;
+
+@Value
+public class CartValidationResult {
+    List<Cart> cartItemList;
+    int totalPrice;
+}

--- a/src/main/java/com/flab/order/global/response/statusEnums/ErrorStatus.java
+++ b/src/main/java/com/flab/order/global/response/statusEnums/ErrorStatus.java
@@ -15,8 +15,14 @@ public enum ErrorStatus implements BaseCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 내의 문제가 발생했습니다."),
 
+    // 회원 MEMBER
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "MEMBER4010", "비밀번호가 일치하지 않습니다."),
-    MEMBER_NOT_EXIST(HttpStatus.NOT_FOUND, "MEMBER4040", "존재하지 않는 회원 정보입니다.");
+    MEMBER_NOT_EXIST(HttpStatus.NOT_FOUND, "MEMBER4040", "존재하지 않는 회원 정보입니다."),
+
+    // 장바구니 CART
+    EMPTY_CART(HttpStatus.UNPROCESSABLE_ENTITY, "CART4220", "장바구니가 비어있습니다."),
+    INVALID_QUANTITY(HttpStatus.CONFLICT, "CART4090", "장바구니에 담긴 상품의 재고가 부족합니다."),
+    INVALID_TOTAL_PRICE(HttpStatus.CONFLICT, "CART4091", "장바구니에 담긴 상품의 총액이 회원의 잔액을 초과하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/flab/order/global/response/statusEnums/ErrorStatus.java
+++ b/src/main/java/com/flab/order/global/response/statusEnums/ErrorStatus.java
@@ -22,7 +22,10 @@ public enum ErrorStatus implements BaseCode {
     // 장바구니 CART
     EMPTY_CART(HttpStatus.UNPROCESSABLE_ENTITY, "CART4220", "장바구니가 비어있습니다."),
     INVALID_QUANTITY(HttpStatus.CONFLICT, "CART4090", "장바구니에 담긴 상품의 재고가 부족합니다."),
-    INVALID_TOTAL_PRICE(HttpStatus.CONFLICT, "CART4091", "장바구니에 담긴 상품의 총액이 회원의 잔액을 초과하였습니다.");
+    INVALID_TOTAL_PRICE(HttpStatus.CONFLICT, "CART4091", "장바구니에 담긴 상품의 총액이 회원의 잔액을 초과하였습니다."),
+
+    // 상품 PRODUCT
+    INVALID_STOCK(HttpStatus.CONFLICT, "PRODUCT4090", "상품의 재고가 부족합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/flab/order/global/response/statusEnums/ErrorStatus.java
+++ b/src/main/java/com/flab/order/global/response/statusEnums/ErrorStatus.java
@@ -18,6 +18,7 @@ public enum ErrorStatus implements BaseCode {
     // 회원 MEMBER
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "MEMBER4010", "비밀번호가 일치하지 않습니다."),
     MEMBER_NOT_EXIST(HttpStatus.NOT_FOUND, "MEMBER4040", "존재하지 않는 회원 정보입니다."),
+    INVALID_BALANCE(HttpStatus.CONFLICT, "MEMBER4090", "회원의 잔액이 부족합니다."),
 
     // 장바구니 CART
     EMPTY_CART(HttpStatus.UNPROCESSABLE_ENTITY, "CART4220", "장바구니가 비어있습니다."),

--- a/src/main/java/com/flab/order/mapper/CartMapper.java
+++ b/src/main/java/com/flab/order/mapper/CartMapper.java
@@ -4,9 +4,12 @@ import com.flab.order.domain.entity.Cart;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 @Mapper
 public interface CartMapper {
     Optional<Cart> findByMemberIdAndProductId(@Param("memberId") Long memberId, @Param("productId") Long productId);
+
+    List<Cart> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/flab/order/mapper/CartMapper.java
+++ b/src/main/java/com/flab/order/mapper/CartMapper.java
@@ -12,4 +12,6 @@ public interface CartMapper {
     Optional<Cart> findByMemberIdAndProductId(@Param("memberId") Long memberId, @Param("productId") Long productId);
 
     List<Cart> findByMemberId(Long memberId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/flab/order/mapper/MemberMapper.java
+++ b/src/main/java/com/flab/order/mapper/MemberMapper.java
@@ -2,6 +2,7 @@ package com.flab.order.mapper;
 
 import com.flab.order.domain.entity.Member;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.Optional;
 
@@ -9,4 +10,5 @@ import java.util.Optional;
 public interface MemberMapper {
     Optional<Member> findById(Long id);
     Optional<Member> findByEmail(String email);
+    int updateByIdAndBalance(@Param("memberId")Long id, @Param("totalPrice")int totalPrice);
 }

--- a/src/main/java/com/flab/order/mapper/OrderDetailMapper.java
+++ b/src/main/java/com/flab/order/mapper/OrderDetailMapper.java
@@ -4,9 +4,12 @@ import com.flab.order.domain.entity.OrderDetail;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 @Mapper
 public interface OrderDetailMapper {
     Optional<OrderDetail> findByOrderIdAndProductId(@Param("orderId")Long orderId, @Param("productId")Long productId);
+
+    void saveAll(List<OrderDetail> orderDetailList);
 }

--- a/src/main/java/com/flab/order/mapper/OrdersMapper.java
+++ b/src/main/java/com/flab/order/mapper/OrdersMapper.java
@@ -2,6 +2,7 @@ package com.flab.order.mapper;
 
 import com.flab.order.domain.entity.Orders;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.Optional;
 
@@ -10,4 +11,6 @@ public interface OrdersMapper {
     Optional<Orders> findById(Long id);
 
     void save(Orders order);
+
+    void updateStatus(@Param("orderId")Long id, @Param("status")String status);
 }

--- a/src/main/java/com/flab/order/mapper/OrdersMapper.java
+++ b/src/main/java/com/flab/order/mapper/OrdersMapper.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 @Mapper
 public interface OrdersMapper {
     Optional<Orders> findById(Long id);
+
+    void save(Orders order);
 }

--- a/src/main/java/com/flab/order/mapper/PaymentMapper.java
+++ b/src/main/java/com/flab/order/mapper/PaymentMapper.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 @Mapper
 public interface PaymentMapper {
     Optional<Payment> findById(Long id);
+
+    void save(Payment payment);
 }

--- a/src/main/java/com/flab/order/mapper/ProductMapper.java
+++ b/src/main/java/com/flab/order/mapper/ProductMapper.java
@@ -1,12 +1,16 @@
 package com.flab.order.mapper;
 
 
+import com.flab.order.domain.entity.Cart;
 import com.flab.order.domain.entity.Product;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 @Mapper
 public interface ProductMapper {
     Optional<Product> findById(Long id);
+    int updateAllByStock(List<Cart> cartItemList);
 }

--- a/src/main/java/com/flab/order/service/CartService.java
+++ b/src/main/java/com/flab/order/service/CartService.java
@@ -24,12 +24,12 @@ public class CartService {
             throw new GeneralHandler(ErrorStatus.EMPTY_CART);
         }
         // 장바구니에 담긴 수량과 상품 재고 비교
-        compareQuantityAndStock(cartItemList);
+        validateStock(cartItemList);
         // 장바구니 상품 총액과 회원 잔액 비교
-        return new CartValidationResult(cartItemList, compareTotalPriceAndBalance(cartItemList, member.getBalance()));
+        return new CartValidationResult(cartItemList, validateBalance(cartItemList, member.getBalance()));
     }
 
-    private void compareQuantityAndStock(List<Cart> cartItemList) {
+    private void validateStock(List<Cart> cartItemList) {
         cartItemList.stream()
                 .filter(cart -> cart.getProduct().getStock() < cart.getQuantity())
                 .findFirst()
@@ -44,7 +44,7 @@ public class CartService {
                 .sum();
     }
 
-    private int compareTotalPriceAndBalance(List<Cart> cartItemList, int balance) {
+    private int validateBalance(List<Cart> cartItemList, int balance) {
         int totalPrice = calculateTotalPrice(cartItemList);
         if (totalPrice > balance) {
             throw new GeneralHandler(ErrorStatus.INVALID_TOTAL_PRICE);

--- a/src/main/java/com/flab/order/service/CartService.java
+++ b/src/main/java/com/flab/order/service/CartService.java
@@ -2,6 +2,7 @@ package com.flab.order.service;
 
 import com.flab.order.domain.entity.Cart;
 import com.flab.order.domain.entity.Member;
+import com.flab.order.domain.vo.CartValidationResult;
 import com.flab.order.global.exception.GeneralHandler;
 import com.flab.order.global.response.statusEnums.ErrorStatus;
 import com.flab.order.mapper.CartMapper;
@@ -15,7 +16,7 @@ import java.util.List;
 public class CartService {
     private final CartMapper cartMapper;
 
-    public void checkStockAndPrice(Member member) {
+    public CartValidationResult checkStockAndPrice(Member member) {
         List<Cart> cartItemList = cartMapper.findByMemberId(member.getId());
         // 장바구니 비어있는지 확인
         if (cartItemList.isEmpty()) {
@@ -24,7 +25,7 @@ public class CartService {
         // 장바구니에 담긴 수량과 상품 재고 비교
         compareQuantityAndStock(cartItemList);
         // 장바구니 상품 총액과 회원 잔액 비교
-        compareTotalPriceAndBalance(cartItemList, member.getBalance());
+        return new CartValidationResult(cartItemList, compareTotalPriceAndBalance(cartItemList, member.getBalance()));
     }
 
     private void compareQuantityAndStock(List<Cart> cartItemList) {
@@ -42,9 +43,11 @@ public class CartService {
                 .sum();
     }
 
-    private void compareTotalPriceAndBalance(List<Cart> cartItemList, int balance) {
-        if (calculateTotalPrice(cartItemList) > balance) {
+    private int compareTotalPriceAndBalance(List<Cart> cartItemList, int balance) {
+        int totalPrice = calculateTotalPrice(cartItemList);
+        if (totalPrice > balance) {
             throw new GeneralHandler(ErrorStatus.INVALID_TOTAL_PRICE);
         }
+        return totalPrice;
     }
 }

--- a/src/main/java/com/flab/order/service/CartService.java
+++ b/src/main/java/com/flab/order/service/CartService.java
@@ -7,6 +7,8 @@ import com.flab.order.global.exception.GeneralHandler;
 import com.flab.order.global.response.statusEnums.ErrorStatus;
 import com.flab.order.mapper.CartMapper;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,12 +17,15 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class CartService {
+    Logger logger = LoggerFactory.getLogger(CartService.class);
+
     private final CartMapper cartMapper;
 
     public CartValidationResult checkStockAndPrice(Member member) {
         List<Cart> cartItemList = cartMapper.findByMemberId(member.getId());
         // 장바구니 비어있는지 확인
         if (cartItemList.isEmpty()) {
+            logger.error("장바구니 비어있음: 회원 ID = {}", member.getId());
             throw new GeneralHandler(ErrorStatus.EMPTY_CART);
         }
         // 장바구니에 담긴 수량과 상품 재고 검증

--- a/src/main/java/com/flab/order/service/CartService.java
+++ b/src/main/java/com/flab/order/service/CartService.java
@@ -1,0 +1,50 @@
+package com.flab.order.service;
+
+import com.flab.order.domain.entity.Cart;
+import com.flab.order.domain.entity.Member;
+import com.flab.order.global.exception.GeneralHandler;
+import com.flab.order.global.response.statusEnums.ErrorStatus;
+import com.flab.order.mapper.CartMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+    private final CartMapper cartMapper;
+
+    public void checkStockAndPrice(Member member) {
+        List<Cart> cartItemList = cartMapper.findByMemberId(member.getId());
+        // 장바구니 비어있는지 확인
+        if (cartItemList.isEmpty()) {
+            throw new GeneralHandler(ErrorStatus.EMPTY_CART);
+        }
+        // 장바구니에 담긴 수량과 상품 재고 비교
+        compareQuantityAndStock(cartItemList);
+        // 장바구니 상품 총액과 회원 잔액 비교
+        compareTotalPriceAndBalance(cartItemList, member.getBalance());
+    }
+
+    private void compareQuantityAndStock(List<Cart> cartItemList) {
+        cartItemList.stream()
+                .filter(cart -> cart.getProduct().getStock() < cart.getQuantity())
+                .findFirst()
+                .ifPresent(cart -> {
+                    throw new GeneralHandler(ErrorStatus.INVALID_QUANTITY);
+                });
+    }
+
+    private int calculateTotalPrice(List<Cart> cartItemList) {
+        return cartItemList.stream()
+                .mapToInt(cart -> cart.getProduct().getPrice() * cart.getQuantity())
+                .sum();
+    }
+
+    private void compareTotalPriceAndBalance(List<Cart> cartItemList, int balance) {
+        if (calculateTotalPrice(cartItemList) > balance) {
+            throw new GeneralHandler(ErrorStatus.INVALID_TOTAL_PRICE);
+        }
+    }
+}

--- a/src/main/java/com/flab/order/service/CartService.java
+++ b/src/main/java/com/flab/order/service/CartService.java
@@ -8,6 +8,7 @@ import com.flab.order.global.response.statusEnums.ErrorStatus;
 import com.flab.order.mapper.CartMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -51,6 +52,7 @@ public class CartService {
         return totalPrice;
     }
 
+    @Transactional
     public void emptyCart(Long memberId){
         cartMapper.deleteByMemberId(memberId);
     }

--- a/src/main/java/com/flab/order/service/CartService.java
+++ b/src/main/java/com/flab/order/service/CartService.java
@@ -50,4 +50,8 @@ public class CartService {
         }
         return totalPrice;
     }
+
+    public void emptyCart(Long memberId){
+        cartMapper.deleteByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/flab/order/service/MemberService.java
+++ b/src/main/java/com/flab/order/service/MemberService.java
@@ -34,4 +34,11 @@ public class MemberService {
         return memberMapper.findById(memberId)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_EXIST));
     }
+
+    @Transactional
+    public void decreaseBalance(Long memberId, int totalPrice){
+        if(memberMapper.updateByIdAndBalance(memberId, totalPrice) == 0){
+            throw new GeneralHandler(ErrorStatus.INVALID_BALANCE);
+        }
+    }
 }

--- a/src/main/java/com/flab/order/service/MemberService.java
+++ b/src/main/java/com/flab/order/service/MemberService.java
@@ -29,4 +29,9 @@ public class MemberService {
         sessionService.setAuthenticatedUser(member);
         return true;
     }
+
+    public Member getMember(Long memberId){
+        return memberMapper.findById(memberId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_EXIST));
+    }
 }

--- a/src/main/java/com/flab/order/service/OrderService.java
+++ b/src/main/java/com/flab/order/service/OrderService.java
@@ -35,7 +35,8 @@ public class OrderService {
         cartService.emptyCart(memberId);
         // 상품 재고 감소
         productService.decreaseStock(cartValidationResult.getCartItemList());
-
+        // 회원 잔액 감소
+        memberService.decreaseBalance(memberId, cartValidationResult.getTotalPrice());
 
         return null;
     }

--- a/src/main/java/com/flab/order/service/OrderService.java
+++ b/src/main/java/com/flab/order/service/OrderService.java
@@ -30,6 +30,8 @@ public class OrderService {
         CartValidationResult cartValidationResult = cartService.checkStockAndPrice(member);
         // 주문서 생성
         createOrder(member, cartValidationResult);
+        // 장바구니 비우기
+        cartService.emptyCart(memberId);
 
         return null;
     }

--- a/src/main/java/com/flab/order/service/OrderService.java
+++ b/src/main/java/com/flab/order/service/OrderService.java
@@ -6,6 +6,8 @@ import com.flab.order.domain.vo.CartValidationResult;
 import com.flab.order.mapper.OrderDetailMapper;
 import com.flab.order.mapper.OrdersMapper;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +17,8 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class OrderService {
+    Logger logger = LoggerFactory.getLogger(OrderService.class);
+
     private final OrdersMapper ordersMapper;
     private final OrderDetailMapper orderDetailMapper;
     private final MemberService memberService;
@@ -25,20 +29,35 @@ public class OrderService {
     public OrderResponse.Success orderCartItems(Long memberId){
         // 로그인 회원 정보 불러오기
         Member member = memberService.getMember(memberId);
+        logger.info("회원 정보 조회 완료: 회원 ID = {}", memberId);
+
         // 장바구니 상품 재고와 가격 확인
         CartValidationResult cartValidationResult = cartService.checkStockAndPrice(member);
+        logger.info("장바구니 상품 재고 및 가격 확인 완료: 회원 ID = {}", memberId);
+
         // 주문서 생성
         Long orderId = createOrder(member, cartValidationResult);
+        logger.info("주문서 생성 완료: 회원 ID = {}, 주문 ID = {}", memberId, orderId);
+
         // 장바구니 비우기
         cartService.emptyCart(memberId);
+        logger.info("장바구니 비움: 회원 ID = {}", memberId);
+
         // 상품 재고 감소
         productService.decreaseStock(cartValidationResult.getCartItemList());
+        logger.info("상품 재고 감소 처리: 회원 ID = {}, 주문 ID = {}", memberId, orderId);
+
         // 회원 잔액 감소
         memberService.decreaseBalance(memberId, cartValidationResult.getTotalPrice());
+        logger.info("회원 잔액 감소 처리: 회원 ID = {}", memberId);
+
         // 결제 처리
         paymentService.processOrderPayment(orderId, cartValidationResult.getTotalPrice());
+        logger.info("결제 처리 완료: 회원 ID = {}, 주문 ID = {}", memberId, orderId);
+
         // 주문 상태 변경: PENDING(대기) -> COMPLETE(완료)
         updateStatusToComplete(orderId);
+        logger.info("주문 처리 완료: 회원 ID = {}, 주문 ID = {}", memberId, orderId);
 
         return null;
     }

--- a/src/main/java/com/flab/order/service/OrderService.java
+++ b/src/main/java/com/flab/order/service/OrderService.java
@@ -1,10 +1,7 @@
 package com.flab.order.service;
 
 import com.flab.order.domain.dto.OrderResponse;
-import com.flab.order.domain.entity.Cart;
-import com.flab.order.domain.entity.Member;
-import com.flab.order.domain.entity.OrderDetail;
-import com.flab.order.domain.entity.Orders;
+import com.flab.order.domain.entity.*;
 import com.flab.order.domain.vo.CartValidationResult;
 import com.flab.order.mapper.OrderDetailMapper;
 import com.flab.order.mapper.OrdersMapper;
@@ -40,6 +37,8 @@ public class OrderService {
         memberService.decreaseBalance(memberId, cartValidationResult.getTotalPrice());
         // 결제 처리
         paymentService.processOrderPayment(orderId, cartValidationResult.getTotalPrice());
+        // 주문 상태 변경: PENDING(대기) -> COMPLETE(완료)
+        updateStatusToComplete(orderId);
 
         return null;
     }
@@ -55,5 +54,9 @@ public class OrderService {
         orderDetailMapper.saveAll(newOrderDetailList);
 
         return newOrder.getId();
+    }
+
+    private void updateStatusToComplete(Long orderId){
+        ordersMapper.updateStatus(orderId, Status.COMPLETE.name());
     }
 }

--- a/src/main/java/com/flab/order/service/OrderService.java
+++ b/src/main/java/com/flab/order/service/OrderService.java
@@ -22,6 +22,7 @@ public class OrderService {
     private final OrderDetailMapper orderDetailMapper;
     private final MemberService memberService;
     private final CartService cartService;
+    private final ProductService productService;
 
     public OrderResponse.Success orderCartItems(Long memberId){
         // 로그인 회원 정보 불러오기
@@ -32,6 +33,9 @@ public class OrderService {
         createOrder(member, cartValidationResult);
         // 장바구니 비우기
         cartService.emptyCart(memberId);
+        // 상품 재고 감소
+        productService.decreaseStock(cartValidationResult.getCartItemList());
+
 
         return null;
     }

--- a/src/main/java/com/flab/order/service/OrderService.java
+++ b/src/main/java/com/flab/order/service/OrderService.java
@@ -9,10 +9,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class OrderService {
     private final MemberService memberService;
+    private final CartService cartService;
     public OrderResponse.Success orderCartItems(Long memberId){
         // 로그인 회원 정보 불러오기
         Member member = memberService.getMember(memberId);
+        // 장바구니 상품 재고와 가격 확인
+        cartService.checkStockAndPrice(member);
+
         return null;
     }
-
 }

--- a/src/main/java/com/flab/order/service/OrderService.java
+++ b/src/main/java/com/flab/order/service/OrderService.java
@@ -27,9 +27,9 @@ public class OrderService {
         // 로그인 회원 정보 불러오기
         Member member = memberService.getMember(memberId);
         // 장바구니 상품 재고와 가격 확인
-        CartValidationResult validationResult = cartService.checkStockAndPrice(member);
+        CartValidationResult cartValidationResult = cartService.checkStockAndPrice(member);
         // 주문서 생성
-        createOrder(member, validationResult);
+        createOrder(member, cartValidationResult);
 
         return null;
     }

--- a/src/main/java/com/flab/order/service/OrderService.java
+++ b/src/main/java/com/flab/order/service/OrderService.java
@@ -1,21 +1,47 @@
 package com.flab.order.service;
 
 import com.flab.order.domain.dto.OrderResponse;
+import com.flab.order.domain.entity.Cart;
 import com.flab.order.domain.entity.Member;
+import com.flab.order.domain.entity.OrderDetail;
+import com.flab.order.domain.entity.Orders;
+import com.flab.order.domain.vo.CartValidationResult;
+import com.flab.order.mapper.OrderDetailMapper;
+import com.flab.order.mapper.OrdersMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class OrderService {
+    private final OrdersMapper ordersMapper;
+    private final OrderDetailMapper orderDetailMapper;
     private final MemberService memberService;
     private final CartService cartService;
+
     public OrderResponse.Success orderCartItems(Long memberId){
         // 로그인 회원 정보 불러오기
         Member member = memberService.getMember(memberId);
         // 장바구니 상품 재고와 가격 확인
-        cartService.checkStockAndPrice(member);
+        CartValidationResult validationResult = cartService.checkStockAndPrice(member);
+        // 주문서 생성
+        createOrder(member, validationResult);
 
         return null;
+    }
+
+    @Transactional
+    public void createOrder(Member member, CartValidationResult validationResult) {
+        Orders newOrder = Orders.createOrder(member.getId(), validationResult.getTotalPrice());
+        ordersMapper.save(newOrder);
+
+        List<OrderDetail> newOrderDetailList = validationResult.getCartItemList().stream()
+                .map(cart -> OrderDetail.createOrderDetail(newOrder.getId(), cart))
+                .collect(Collectors.toList());
+        orderDetailMapper.saveAll(newOrderDetailList);
     }
 }

--- a/src/main/java/com/flab/order/service/OrderService.java
+++ b/src/main/java/com/flab/order/service/OrderService.java
@@ -1,0 +1,18 @@
+package com.flab.order.service;
+
+import com.flab.order.domain.dto.OrderResponse;
+import com.flab.order.domain.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+    private final MemberService memberService;
+    public OrderResponse.Success orderCartItems(Long memberId){
+        // 로그인 회원 정보 불러오기
+        Member member = memberService.getMember(memberId);
+        return null;
+    }
+
+}

--- a/src/main/java/com/flab/order/service/OrderService.java
+++ b/src/main/java/com/flab/order/service/OrderService.java
@@ -1,5 +1,6 @@
 package com.flab.order.service;
 
+import com.flab.order.converter.OrderConverter;
 import com.flab.order.domain.dto.OrderResponse;
 import com.flab.order.domain.entity.*;
 import com.flab.order.domain.vo.CartValidationResult;
@@ -59,7 +60,7 @@ public class OrderService {
         updateStatusToComplete(orderId);
         logger.info("주문 처리 완료: 회원 ID = {}, 주문 ID = {}", memberId, orderId);
 
-        return null;
+        return OrderConverter.toSuccess(cartValidationResult);
     }
 
     @Transactional

--- a/src/main/java/com/flab/order/service/PaymentService.java
+++ b/src/main/java/com/flab/order/service/PaymentService.java
@@ -1,2 +1,16 @@
-package com.flab.order.service;public class PaymentService {
+package com.flab.order.service;
+
+import com.flab.order.domain.entity.Payment;
+import com.flab.order.mapper.PaymentMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+    private final PaymentMapper paymentMapper;
+
+    public void processOrderPayment(Long orderId, int totalPrice){
+        paymentMapper.save(Payment.createPayment(orderId, totalPrice));
+    }
 }

--- a/src/main/java/com/flab/order/service/PaymentService.java
+++ b/src/main/java/com/flab/order/service/PaymentService.java
@@ -1,0 +1,2 @@
+package com.flab.order.service;public class PaymentService {
+}

--- a/src/main/java/com/flab/order/service/ProductService.java
+++ b/src/main/java/com/flab/order/service/ProductService.java
@@ -1,0 +1,24 @@
+package com.flab.order.service;
+
+import com.flab.order.domain.entity.Cart;
+import com.flab.order.global.exception.GeneralHandler;
+import com.flab.order.global.response.statusEnums.ErrorStatus;
+import com.flab.order.mapper.ProductMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+    private final ProductMapper productMapper;
+
+    @Transactional
+    public void decreaseStock(List<Cart> cartItemList) {
+        if(productMapper.updateAllByStock(cartItemList) != cartItemList.size()){
+            throw new GeneralHandler(ErrorStatus.INVALID_STOCK);
+        }
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,11 +1,18 @@
 INSERT INTO `MEMBER` (`email`, `name`, `password`, `phone`, `address`, `balance`, `createdAt`, `updatedAt`) VALUES
-    ('member@example.com', '김멤버', '1234', '123-456-7890', '서울시 중구', 100000, NOW(), NOW()),
-    ('member2@example.com', '회원 2', 'password2', '010-0000-0002', 'Address 1', 50000, NOW(), NOW()),
-    ('member3@example.com', '회원 3', 'password3', '010-0000-0003', 'Address 2', 60000, NOW(), NOW());
+    ('member1@example.com', '회원 1', 'password1', '010-0000-0001', 'Address 1', 50000, NOW(), NOW()),
+    ('member2@example.com', '회원 2', 'password2', '010-0000-0002', 'Address 2', 50000, NOW(), NOW()),
+    ('member3@example.com', '회원 3', 'password3', '010-0000-0003', 'Address 3', 60000, NOW(), NOW()),
+    ('member4@example.com', '회원 4', 'password4', '010-0000-0004', 'Address 4', 60000, NOW(), NOW()),
+    ('member5@example.com', '회원 5', 'password5', '010-0000-0005', 'Address 5', 80000, NOW(), NOW()),
+    ('member6@example.com', '회원 6', 'password6', '010-0000-0006', 'Address 6', 100000, NOW(), NOW()),
+    ('member7@example.com', '회원 7', 'password7', '010-0000-0007', 'Address 7', 50000, NOW(), NOW()),
+    ('member8@example.com', '회원 8', 'password8', '010-0000-0008', 'Address 8', 70000, NOW(), NOW());
 
 INSERT INTO `PRODUCT` (`name`, `description`, `price`, `stock`, `createdAt`) VALUES
     ('제품1', '더미 제품1 입니다.', 7500, 100, NOW()),
-    ('제품2', '더미 제품2 입니다.', 5000, 1, NOW());
+    ('제품2', '더미 제품2 입니다.', 5000, 1, NOW()),
+    ('제품3', '더미 제품3 입니다.', 10000, 5, NOW()),
+    ('제품4', '더미 제품4 입니다.', 20000, 2, NOW());
 
 INSERT INTO `ORDERS` (`memberId`, `status`, `totalPrice`, `createdAt`, `updatedAt`) VALUES
     ('1', 'COMPLETE', 7500, NOW(), NOW());
@@ -19,4 +26,11 @@ INSERT INTO `PAYMENT` (`orderId`, `amount`, `status`, `createdAt`, `updatedAt`) 
 INSERT INTO `CART` (`memberId`, `productId`, `quantity`, `createdAt`) VALUES
     ('1', '1', 1, NOW()),
     ('2', '2', 1, NOW()),
-    ('3', '2', 1, NOW());
+    ('3', '2', 1, NOW()),
+
+    ('4', '3', 3, NOW()),
+    ('5', '3', 4, NOW()),
+    ('6', '3', 2, NOW()),
+
+    ('7', '4', 3, NOW()),
+    ('8', '4', 4, NOW());

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,8 +1,11 @@
 INSERT INTO `MEMBER` (`email`, `name`, `password`, `phone`, `address`, `balance`, `createdAt`, `updatedAt`) VALUES
-    ('member@example.com', '김멤버', '1234', '123-456-7890', '서울시 중구', 100000, NOW(), NOW());
+    ('member@example.com', '김멤버', '1234', '123-456-7890', '서울시 중구', 100000, NOW(), NOW()),
+    ('member2@example.com', '회원 2', 'password2', '010-0000-0002', 'Address 1', 50000, NOW(), NOW()),
+    ('member3@example.com', '회원 3', 'password3', '010-0000-0003', 'Address 2', 60000, NOW(), NOW());
 
 INSERT INTO `PRODUCT` (`name`, `description`, `price`, `stock`, `createdAt`) VALUES
-    ('제품1', '더미 제품1 입니다.', 7500, 100, NOW());
+    ('제품1', '더미 제품1 입니다.', 7500, 100, NOW()),
+    ('제품2', '더미 제품2 입니다.', 5000, 1, NOW());
 
 INSERT INTO `ORDERS` (`memberId`, `status`, `totalPrice`, `createdAt`, `updatedAt`) VALUES
     ('1', 'COMPLETE', 7500, NOW(), NOW());
@@ -14,4 +17,6 @@ INSERT INTO `PAYMENT` (`orderId`, `amount`, `status`, `createdAt`, `updatedAt`) 
     ('1', 7500, 'COMPLETE', NOW(), NOW());
 
 INSERT INTO `CART` (`memberId`, `productId`, `quantity`, `createdAt`) VALUES
-    ('1', '1', 1, NOW());
+    ('1', '1', 1, NOW()),
+    ('2', '2', 1, NOW()),
+    ('3', '2', 1, NOW());

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -6,13 +6,28 @@ INSERT INTO `MEMBER` (`email`, `name`, `password`, `phone`, `address`, `balance`
     ('member5@example.com', '회원 5', 'password5', '010-0000-0005', 'Address 5', 80000, NOW(), NOW()),
     ('member6@example.com', '회원 6', 'password6', '010-0000-0006', 'Address 6', 100000, NOW(), NOW()),
     ('member7@example.com', '회원 7', 'password7', '010-0000-0007', 'Address 7', 50000, NOW(), NOW()),
-    ('member8@example.com', '회원 8', 'password8', '010-0000-0008', 'Address 8', 70000, NOW(), NOW());
+    ('member8@example.com', '회원 8', 'password8', '010-0000-0008', 'Address 8', 70000, NOW(), NOW()),
+    ('member9@example.com', '회원 9', 'password9', '010-0000-0009', 'Address 9', 50000, NOW(), NOW()),
+    ('member10@example.com', '회원 10', 'password10', '010-0000-0010', 'Address 10', 50000, NOW(), NOW()),
+
+-- 상품 재고 동시성 테스트 시나리오 4
+    ('member11@example.com', '회원 11', 'password11', '010-0000-0011', 'Address 11', 30000, NOW(), NOW()),
+    ('member12@example.com', '회원 12', 'password12', '010-0000-0012', 'Address 12', 30000, NOW(), NOW()),
+    ('member13@example.com', '회원 13', 'password13', '010-0000-0013', 'Address 13', 30000, NOW(), NOW()),
+    ('member14@example.com', '회원 14', 'password14', '010-0000-0014', 'Address 14', 30000, NOW(), NOW()),
+    ('member15@example.com', '회원 15', 'password15', '010-0000-0015', 'Address 15', 30000, NOW(), NOW()),
+    ('member16@example.com', '회원 16', 'password16', '010-0000-0016', 'Address 16', 30000, NOW(), NOW()),
+    ('member17@example.com', '회원 17', 'password17', '010-0000-0017', 'Address 17', 30000, NOW(), NOW()),
+    ('member18@example.com', '회원 18', 'password18', '010-0000-0018', 'Address 18', 30000, NOW(), NOW()),
+    ('member19@example.com', '회원 19', 'password19', '010-0000-0019', 'Address 19', 30000, NOW(), NOW()),
+    ('member20@example.com', '회원 20', 'password20', '010-0000-0020', 'Address 20', 30000, NOW(), NOW());
 
 INSERT INTO `PRODUCT` (`name`, `description`, `price`, `stock`, `createdAt`) VALUES
     ('제품1', '더미 제품1 입니다.', 7500, 100, NOW()),
     ('제품2', '더미 제품2 입니다.', 5000, 1, NOW()),
     ('제품3', '더미 제품3 입니다.', 10000, 5, NOW()),
-    ('제품4', '더미 제품4 입니다.', 20000, 2, NOW());
+    ('제품4', '더미 제품4 입니다.', 20000, 2, NOW()),
+    ('제품5', '더미 제품5 입니다.', 9900, 6, NOW());
 
 INSERT INTO `ORDERS` (`memberId`, `status`, `totalPrice`, `createdAt`, `updatedAt`) VALUES
     ('1', 'COMPLETE', 7500, NOW(), NOW());
@@ -33,4 +48,16 @@ INSERT INTO `CART` (`memberId`, `productId`, `quantity`, `createdAt`) VALUES
     ('6', '3', 2, NOW()),
 
     ('7', '4', 3, NOW()),
-    ('8', '4', 4, NOW());
+    ('8', '4', 4, NOW()),
+
+-- 상품 재고 동시성 테스트 시나리오 4
+    ('11', '5', 1, NOW()),
+    ('12', '5', 1, NOW()),
+    ('13', '5', 1, NOW()),
+    ('14', '5', 1, NOW()),
+    ('15', '5', 1, NOW()),
+    ('16', '5', 1, NOW()),
+    ('17', '5', 1, NOW()),
+    ('18', '5', 1, NOW()),
+    ('19', '5', 1, NOW()),
+    ('20', '5', 1, NOW());

--- a/src/main/resources/mappers/CartMapper.xml
+++ b/src/main/resources/mappers/CartMapper.xml
@@ -5,4 +5,21 @@
         SELECT * FROM CART
         WHERE memberId = #{memberId} AND productId = #{productId}
     </select>
+
+    <select id="findByMemberId" resultType="com.flab.order.domain.entity.Cart">
+        SELECT c.memberId,
+               c.productId,
+               c.quantity,
+               c.createdAt,
+               p.id          AS "product.id",
+               p.name        AS "product.name",
+               p.description AS "product.description",
+               p.price       AS "product.price",
+               p.stock       AS "product.stock",
+               p.createdAt   AS "product.createdAt"
+        FROM cart c
+                 JOIN product p ON c.productId = p.id
+        WHERE c.memberId = #{memberId}
+    </select>
+
 </mapper>

--- a/src/main/resources/mappers/CartMapper.xml
+++ b/src/main/resources/mappers/CartMapper.xml
@@ -22,4 +22,8 @@
         WHERE c.memberId = #{memberId}
     </select>
 
+    <delete id="deleteByMemberId" parameterType="long">
+        DELETE FROM Cart WHERE memberId = #{memberId}
+    </delete>
+
 </mapper>

--- a/src/main/resources/mappers/MemberMapper.xml
+++ b/src/main/resources/mappers/MemberMapper.xml
@@ -8,4 +8,10 @@
     <select id="findByEmail" parameterType="java.lang.String" resultType="com.flab.order.domain.entity.Member">
         SELECT * FROM MEMBER WHERE email = #{email}
     </select>
+
+    <update id="updateByIdAndBalance" parameterType="map">
+        UPDATE MEMBER
+        SET balance = balance - #{totalPrice}
+        WHERE id = #{memberId} AND balance >= #{totalPrice}
+    </update>
 </mapper>

--- a/src/main/resources/mappers/OrderDetailMapper.xml
+++ b/src/main/resources/mappers/OrderDetailMapper.xml
@@ -5,4 +5,12 @@
         SELECT * FROM ORDER_DETAIL
         WHERE orderId = #{orderId} AND productId = #{productId}
     </select>
+
+    <insert id="saveAll" parameterType="list">
+        INSERT INTO ORDER_DETAIL (orderId, productId, price, quantity)
+        VALUES
+        <foreach collection="list" item="detail" separator=",">
+            (#{detail.orderId}, #{detail.productId}, #{detail.price}, #{detail.quantity})
+        </foreach>
+    </insert>
 </mapper>

--- a/src/main/resources/mappers/OrdersMapper.xml
+++ b/src/main/resources/mappers/OrdersMapper.xml
@@ -9,4 +9,10 @@
         INSERT INTO Orders (memberId, status, totalPrice, createdAt, updatedAt)
         VALUES (#{memberId}, #{status}, #{totalPrice}, #{createdAt}, #{updatedAt})
     </insert>
+
+    <update id="updateStatus" parameterType="map">
+        UPDATE ORDERS
+        SET status = #{status}
+        WHERE id = #{orderId}
+    </update>
 </mapper>

--- a/src/main/resources/mappers/OrdersMapper.xml
+++ b/src/main/resources/mappers/OrdersMapper.xml
@@ -4,4 +4,9 @@
     <select id="findById" parameterType="java.lang.Long" resultType="com.flab.order.domain.entity.Orders">
         SELECT * FROM ORDERS WHERE id = #{id}
     </select>
+
+    <insert id="save" parameterType="com.flab.order.domain.entity.Orders" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO Orders (memberId, status, totalPrice, createdAt, updatedAt)
+        VALUES (#{memberId}, #{status}, #{totalPrice}, #{createdAt}, #{updatedAt})
+    </insert>
 </mapper>

--- a/src/main/resources/mappers/PaymentMapper.xml
+++ b/src/main/resources/mappers/PaymentMapper.xml
@@ -4,4 +4,9 @@
     <select id="findById" parameterType="java.lang.Long" resultType="com.flab.order.domain.entity.Payment">
         SELECT * FROM PAYMENT WHERE id = #{id}
     </select>
+
+    <insert id="save" parameterType="com.flab.order.domain.entity.Payment">
+        INSERT INTO Payment (orderId, amount, status, createdAt, updatedAt)
+        VALUES (#{orderId}, #{amount}, #{status}, #{createdAt}, #{updatedAt})
+    </insert>
 </mapper>

--- a/src/main/resources/mappers/ProductMapper.xml
+++ b/src/main/resources/mappers/ProductMapper.xml
@@ -4,4 +4,12 @@
     <select id="findById" parameterType="java.lang.Long" resultType="com.flab.order.domain.entity.Product">
         SELECT * FROM PRODUCT WHERE id = #{id}
     </select>
+
+    <update id="updateAllByStock">
+        <foreach collection="list" item="item" separator=",">
+            UPDATE PRODUCT
+            SET stock = stock - #{item.quantity}
+            WHERE id = #{item.productId} AND stock >= #{item.quantity}
+        </foreach>
+    </update>
 </mapper>

--- a/src/test/java/com/flab/order/service/OrderServiceTest.java
+++ b/src/test/java/com/flab/order/service/OrderServiceTest.java
@@ -1,0 +1,71 @@
+package com.flab.order.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+public class OrderServiceTest {
+
+    Logger logger = LoggerFactory.getLogger(OrderServiceTest.class);
+
+    @Autowired
+    private OrderService orderService;
+
+    private ExecutorService executorService;
+
+    @BeforeEach
+    void setUp() {
+        executorService = Executors.newFixedThreadPool(2);
+    }
+
+    @AfterEach
+    void tearDown() throws InterruptedException {
+        executorService.shutdown();
+        if (!executorService.awaitTermination(1, TimeUnit.MINUTES)) {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    @DisplayName("[시나리오 1] 2명의 회원이 동시에 재고가 1인 상품 주문 시도") // 상품 재고가 -1 이하가 되어서는 안됨
+    void testOrderConcurrency() {
+        Long memberId1 = 2L;
+        Long memberId2 = 3L;
+
+        Future<?> future1 = executorService.submit(() -> orderService.orderCartItems(memberId1));
+        Future<?> future2 = executorService.submit(() -> orderService.orderCartItems(memberId2));
+
+        int exceptionCount = 0;
+
+        try {
+            future1.get();
+            logger.info("[TEST] 회원 2가 성공적으로 상품 2를 주문했습니다.");
+        } catch (Exception e) {
+            logger.info("[TEST] 회원 2가 상품 2 주문에 실패했습니다. " + e.getMessage());
+            exceptionCount++;
+        }
+
+        try {
+            future2.get(); // 두 번째 작업의 완료와 예외 검사
+            logger.info("[TEST] 회원 3이 성공적으로 상품 2를 주문했습니다.");
+        } catch (Exception e) {
+            logger.info("[TEST] 회원 3이 상품 2 주문에 실패했습니다. " + e.getMessage());
+            exceptionCount++;
+        }
+
+        assertEquals(1, exceptionCount, "회원 한 명의 주문을 성공적으로 처리했습니다.");
+    }
+}

--- a/src/test/java/com/flab/order/service/OrderServiceTest.java
+++ b/src/test/java/com/flab/order/service/OrderServiceTest.java
@@ -98,4 +98,34 @@ public class OrderServiceTest {
 
         assertEquals(1, successCount, "상품 재고 동시성 테스트에 실패했습니다.");
     }
+
+    @Test
+    @DisplayName("[시나리오 3] 2명의 회원이 동시에 재고가 5인 상품을 각각 3개, 2개 주문 시도")
+    void testOrderConcurrency3() {
+        Long memberId1 = 4L;
+        Long memberId2 = 6L;
+
+        Future<?> future1 = executorService.submit(() -> orderService.orderCartItems(memberId1));
+        Future<?> future2 = executorService.submit(() -> orderService.orderCartItems(memberId2));
+
+        int successCount = 0;
+
+        try {
+            future1.get();
+            logger.info("[TEST] 회원 4가 성공적으로 상품 3을 주문했습니다.");
+            successCount++;
+        } catch (Exception e) {
+            logger.info("[TEST] 회원 4가 상품 3 주문에 실패했습니다. " + e.getMessage());
+        }
+
+        try {
+            future2.get();
+            logger.info("[TEST] 회원 6이 성공적으로 상품 3을 주문했습니다.");
+            successCount++;
+        } catch (Exception e) {
+            logger.info("[TEST] 회원 6이 상품 3 주문에 실패했습니다. " + e.getMessage());
+        }
+
+        assertEquals(2, successCount, "상품 재고 동시성 테스트에 실패했습니다.");
+    }
 }

--- a/src/test/java/com/flab/order/service/OrderServiceTest.java
+++ b/src/test/java/com/flab/order/service/OrderServiceTest.java
@@ -48,24 +48,24 @@ public class OrderServiceTest {
         Future<?> future1 = executorService.submit(() -> orderService.orderCartItems(memberId1));
         Future<?> future2 = executorService.submit(() -> orderService.orderCartItems(memberId2));
 
-        int exceptionCount = 0;
+        int successCount = 0;
 
         try {
             future1.get();
             logger.info("[TEST] 회원 2가 성공적으로 상품 2를 주문했습니다.");
+            successCount++;
         } catch (Exception e) {
             logger.info("[TEST] 회원 2가 상품 2 주문에 실패했습니다. " + e.getMessage());
-            exceptionCount++;
         }
 
         try {
-            future2.get(); // 두 번째 작업의 완료와 예외 검사
+            future2.get();
             logger.info("[TEST] 회원 3이 성공적으로 상품 2를 주문했습니다.");
+            successCount++;
         } catch (Exception e) {
             logger.info("[TEST] 회원 3이 상품 2 주문에 실패했습니다. " + e.getMessage());
-            exceptionCount++;
         }
 
-        assertEquals(1, exceptionCount, "상품 재고 동시성 테스트에 실패했습니다.");
+        assertEquals(1, successCount, "상품 재고 동시성 테스트에 실패했습니다.");
     }
 }

--- a/src/test/java/com/flab/order/service/OrderServiceTest.java
+++ b/src/test/java/com/flab/order/service/OrderServiceTest.java
@@ -41,7 +41,7 @@ public class OrderServiceTest {
 
     @Test
     @DisplayName("[시나리오 1] 2명의 회원이 동시에 재고가 1인 상품 주문 시도") // 상품 재고가 -1 이하가 되어서는 안됨
-    void testOrderConcurrency() {
+    void testOrderConcurrency1() {
         Long memberId1 = 2L;
         Long memberId2 = 3L;
 
@@ -66,6 +66,6 @@ public class OrderServiceTest {
             exceptionCount++;
         }
 
-        assertEquals(1, exceptionCount, "회원 한 명의 주문을 성공적으로 처리했습니다.");
+        assertEquals(1, exceptionCount, "상품 재고 동시성 테스트에 실패했습니다.");
     }
 }

--- a/src/test/java/com/flab/order/service/OrderServiceTest.java
+++ b/src/test/java/com/flab/order/service/OrderServiceTest.java
@@ -68,4 +68,34 @@ public class OrderServiceTest {
 
         assertEquals(1, successCount, "상품 재고 동시성 테스트에 실패했습니다.");
     }
+
+    @Test
+    @DisplayName("[시나리오 2] 2명의 회원이 동시에 재고가 5인 상품을 각각 3개, 4개 주문 시도") // 상품 재고가 -1 이하가 되어서는 안됨
+    void testOrderConcurrency2() {
+        Long memberId1 = 4L;
+        Long memberId2 = 5L;
+
+        Future<?> future1 = executorService.submit(() -> orderService.orderCartItems(memberId1));
+        Future<?> future2 = executorService.submit(() -> orderService.orderCartItems(memberId2));
+
+        int successCount = 0;
+
+        try {
+            future1.get();
+            logger.info("[TEST] 회원 4가 성공적으로 상품 3을 주문했습니다.");
+            successCount++;
+        } catch (Exception e) {
+            logger.info("[TEST] 회원 4가 상품 3 주문에 실패했습니다. " + e.getMessage());
+        }
+
+        try {
+            future2.get();
+            logger.info("[TEST] 회원 5가 성공적으로 상품 3을 주문했습니다.");
+            successCount++;
+        } catch (Exception e) {
+            logger.info("[TEST] 회원 5가 상품 3 주문에 실패했습니다. " + e.getMessage());
+        }
+
+        assertEquals(1, successCount, "상품 재고 동시성 테스트에 실패했습니다.");
+    }
 }


### PR DESCRIPTION
## ✏️ 작업 요약
로그인된 회원의 장바구니 상품 목록을 주문하는 기능을 구현했습니다.

## ✨ 작업 내용 및 리뷰 포인트
### 1. 시퀀스 다이어그램
<img width="735" alt="image" src="https://github.com/f-lab-edu/order-service/assets/93423346/d0e71f79-1f1c-406e-a9f0-898f954745ee">

https://github.com/f-lab-edu/order-service/blob/882474768034838734f3a0d085f6d1cd2f2586e7/src/main/java/com/flab/order/service/OrderService.java#L30-L64

- 주문 처리 성공 시 다음의 응답을 반환합니다.
```
"result": {
    "orderStatus": "COMPLETE",
    "productDetails": {
        "productInfoList": [
            {
                "name": "제품1",
                "price": 7500,
                "stock": 100
            }
        ],
        "totalPrice": 7500
    }
}
```

- 주문서 생성(Order, OrderDetail 테이블 insert) 이후의 로직에서 예외가 발생한 경우, Order의 status가 PENDING인 상태로 남겨지고 장바구니는 비워집니다. 이렇게 status가 PENDING으로 남겨진 경우를 주문 처리에 실패한 경우로 생각하고 있습니다.

### 2. 동시성 테스트(상품 재고가 -1 이하가 되는 순간)
초기에는 공유 자원(상품 재고 등)에 대한 동시성 고려보다는 주문 기능의 로직에 집중했고, 기능 구현 후 동시성 테스트를 활용하여 재고가 -1 이하가 되는 상황을 확인하고 개선하고자 했습니다.

이를 위해 2명의 회원이 동시에 한정된 상품 재고를 점유하는 시나리오를 구성했습니다. 동시성과 관련해서 SQL문에 락을 걸거나 명시적인 비즈니스 로직을 구현한 적은 없었기에 실패할 거라고 예상했으나 실제로는 테스트에 통과하는 상황이 발생했습니다. 재고의 수를 조절하거나 회원의 수를 늘리는 등의 추가 시나리오를 작성해 보아도 모두 성공하는 일이 발생했습니다.

결과적으로는 좋은 일이지만 이유를 모르겠어 여러 문서를 찾아본 결과, MySQL 공식 문서에서 답을 찾을 수 있었습니다.

> "For locking reads (SELECT with FOR UPDATE or LOCK IN SHARE MODE), UPDATE, and DELETE statements, locking depends on whether the statement uses a unique index with a unique search condition or a range-type search condition.
> 
> For a unique index with a unique search condition, InnoDB locks only the index record found, not the gap before it.
> 
> For other search conditions, InnoDB locks the index range scanned, using gap locks or next-key locks to block insertions by other sessions into the gaps covered by the range."

위 인용문에 따르면, MySQL의 InnoDB는 두 가지 유형의 검색 조건에 따라 락을 다르게 적용합니다. 유니크 인덱스를 사용하는 경우 해당 인덱스 레코드에만 락을 적용하며, 갭 락은 사용되지 않습니다. 그러나 범위 검색 조건(stock >= 1과 같은)을 사용할 때는 스캔된 인덱스 범위에 대해 갭 락 또는 넥스트키 락을 사용하여 다른 세션에서 해당 범위 내에 삽입하는 것을 차단합니다.

이를 확인하기 위해 MySQL Workbench를 사용하여 실험을 진행했고, 상품 재고 업데이트 쿼리에 대해 두 가지 락이 걸리는 것을 확인할 수 있었습니다.
<img width="640" alt="image" src="https://github.com/f-lab-edu/order-service/assets/93423346/b53b2173-941d-40b2-8fc4-e958b35506a9">
<img width="357" alt="image" src="https://github.com/f-lab-edu/order-service/assets/93423346/c2b697d3-a891-4370-aaa9-f88669ebd318">

- IX (Intent Exclusive) Lock - Table
- X (Exclusive) Lock - Record + REC_NOT_GAP

이 메커니즘 덕분에 다른 트랜잭션에서 해당 레코드를 접근하려 할 때 락으로 인한 대기 상태가 발생했고, 재고가 예상치 못하게 -1 이하로 떨어지는 상황이 발생하지 않았습니다. update 시에 대상 행(하나의 행)에만 락이 걸린다는 점에서 데이터가 많아지더라도 성능적으로 큰 문제를 야기하지 않을 것이라고 생각되긴 합니다만, 최선의 경우인지에 대해서는 다른 방안에 대한 tps를 측정하고 비교해보는 과정이 필요할 것 같습니다.

## 🔖 이슈 번호
- [x] #4 

## 🔗 참고 자료(선택)
[MySQL 공식 문서 - 14.7.2.1 Transaction Isolation Levels](https://dev.mysql.com/doc/refman/5.7/en/innodb-transaction-isolation-levels.html)
